### PR TITLE
fix: moved chown -R to after retrieving package.json file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,10 +102,10 @@ sed -i "s/name: My Company/name: $BS_NAME/g" app-config.yaml
 # Starting Backstage.io
 echo "Starting Backstage.io" >> $HOME/firstboot.log
 
-chown -R $USER:$USER $HOME/backstage-playground
-
 echo "Installing new Yarn packages" >> $HOME/firstboot.log
 wget -O $HOME/backstage-playground/package.json https://raw.githubusercontent.com/itmagix/backstage-oneclick/feature/first-boot-script-before-deploying-backstage/package.json >> $HOME/firstboot.log
+
+chown -R $USER:$USER $HOME/backstage-playground
 
 echo "Installing new Yarn packages" >> $HOME/firstboot.log
 yarn install >> $HOME/firstboot.log

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,7 @@ echo "Starting Backstage.io" >> $HOME/firstboot.log
 echo "Installing new Yarn packages" >> $HOME/firstboot.log
 wget -O $HOME/backstage-playground/package.json https://raw.githubusercontent.com/itmagix/backstage-oneclick/feature/first-boot-script-before-deploying-backstage/package.json >> $HOME/firstboot.log
 
-chown -R $USER:$USER $HOME/backstage-playground
+chown -R $USER:$USER $HOME/backstage-playground/
 
 echo "Installing new Yarn packages" >> $HOME/firstboot.log
 yarn install >> $HOME/firstboot.log


### PR DESCRIPTION
When trying to follow instructions for setting up postgresql: https://backstage.io/docs/getting-started/configuration 

Backstage environment would fail on command:
`yarn add --cwd packages/backend pg`

This was because the packages folder found in: `backstage-playground/packages/app/node_modules' was not owned by current user.

By moving chown -R from first-boot.sh script to later in the script, this problem is resolved.

Have tested on a new VM to make sure it works.